### PR TITLE
Address naming and i18n conventions 

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,4 +1,4 @@
-# Co-Authors Roles 
+# Co-Authors Roles
 ### Concepts & Scope definitions
 
 *Problem:* The existing Co-Authors Plus plugin allows for listing multiple
@@ -6,7 +6,7 @@ authors on one article, but not for specifying the roles which those
 "authors" played. This doesn't serve the needs of more complex newsrooms,
 which may want to acknowledge contributors who played many different
 roles: 'additional reporting', 'photography', 'supporting research', and
-so on. 
+so on.
 
 Basically, we want to take something which enables data like this:
 
@@ -32,13 +32,12 @@ and make it work with output formats like these:
   a post in the same way as Users. This data structure will not be
   changed.
 
-- Users should be able to define a list of Contributor Roles to which
-  "Co-Authors" can be assigned on a post-by-post basis, or use a set of
-  predefined defaults. One of these roles must be chosen as the default or
-  primary author role, which is equivalent to WP_Post->post_author on
-  a standard WordPress site.  (WordPress template functions like
-  `get_author()` should return the first author set in this primary role
-  on a post.)
+- Users should be able to define a list of Author Roles to which "Authors"
+  can be assigned on a post-by-post basis, or use a set of predefined defaults.
+  One of these roles must be chosen as the default or primary author role,
+  which is equivalent to WP_Post->post_author on a standard WordPress site.
+  (WordPress template functions like `get_author()` should return the first
+  author set in this primary role on a post.)
 
 - Any number of "authors" - whether existing users or "guest author" mock
   users - can be attached to any post object with any one of these "role"
@@ -46,9 +45,9 @@ and make it work with output formats like these:
   created in the existing Co-Authors Plus plugin, will default to "primary
   author" or the default role).
 
-- Each Contributor Role term should have a predefined set of "labels" attached to
-  it for display in different formats. _eg:_ 
-      
+- Each Author Role term should have a predefined set of "labels" attached to it
+  for display in different formats. _eg:_
+
       name         | name_user_role_singular | post_relationship_by
       ------------ | ----------------------- | ----------------------------------------
       Author       | Primary Author          | by %s
@@ -56,30 +55,30 @@ and make it work with output formats like these:
       Photography  | Photographer            | Photography by %s
       Researcher   | Supporting Research     | Supporting research by %s
 
-  > Questions: 
+  > Questions:
   >
   > - These terms, and the labels attached to them, should be modifiable
   >   through an API similar to the WordPress functions
   >   `register_post_type()` or `register_taxonomy()`.
   > - Can a set of labels sufficent for all expected use cases be
   >   generated? If not, it may be necessary to allow the list of labels
-  >   themselves to be filtered. 
+  >   themselves to be filtered.
 
-- Theme templates can display this Role / "Co-Author" data in a number of
-  ways, as in the following examples:
-  
-  * a list of credits (all contributor role relationships on the current
-    post, grouped by role, with roles ordered in site-default or
-    user-defined order) in an entry footer,
+- Theme templates can display this Author Role / data in a number of ways, as
+  in the following examples:
+
+  * a list of credits (all author role relationships on the current post,
+	grouped by role, with roles ordered in site-default or user-defined order)
+  in an entry footer,
 
   * an abbreviated byline list (listing only authors with certain roles --
     "primary author" and "contributing author", for example) in an article
     header entry-meta line,
-    
+
   * a list of all posts a given author has contributing roles on, optionally
     grouped by role, on an author archive page, whether for a WP user
     or a "guest author".
-  
+
 - All of this data should be exposed in the WP_Query API, so that queries
   like:
 
@@ -124,7 +123,7 @@ and make it work with output formats like these:
 
 The public front-end interface in Co-Authors Plus consists of a set of eight
 high-level template tag functions, and a few public lower-level helper
-functions for more advanced integration. 
+functions for more advanced integration.
 
 These will need to be replaced with new template functions: the existing
 functions do not have filterable output, and the type of output the

--- a/co-authors-plus-roles.php
+++ b/co-authors-plus-roles.php
@@ -44,7 +44,7 @@ class CoAuthorsPlusRoles {
 			update_option( 'co_authors_plus_roles__notices',
 				array(
 					'class' => 'error',
-					'message' => __( 'You must have Co-Authors Plus installed and activated first in order to use this plugin.' )
+					'message' => __( 'You must have Co-Authors Plus installed and activated first in order to use this plugin.', 'co-authors-plus-roles' )
 				)
 			);
 			deactivate_plugins( __FILE__ );

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -412,14 +412,14 @@ function update_coauthors_on_post( $post_id, $new_coauthors ) {
 		// Right now it just appends, so you can never delete an author from a post.
 		foreach ( $new_coauthors as $coauthor ) {
 
-			// Parse and sanitize terms. `set_contributor_on_post` does
+			// Parse and sanitize terms. `set_author_on_post` does
 			// some type checking of its parameters, so we coerce the
 			// posted string into the expected types here.
 			list( $author, $role ) = explode( '|||', $coauthor );
 			$author = intval( $author );
 			$role = get_author_role( $role );
 
-			set_contributor_on_post( $post_id, $author, $role );
+			set_author_on_post( $post_id, $author, $role );
 
 		}
 	}
@@ -456,7 +456,7 @@ function action_update_coauthors_on_post( $post_id, $post ) {
 			$user = get_userdata( $post->post_author );
 
 			if ( $user )
-				set_contributor_on_post( $post_id, $user->user_login );
+				set_author_on_post( $post_id, $user->user_login );
 		}
 	}
 }

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -43,7 +43,7 @@ function add_meta_boxes() {
 			$coauthors_plus->current_user_can_set_authors() ) {
 		add_meta_box(
 			'coauthorsrolesdiv',
-			__( 'Authors', 'co-authors-plus' ),
+			__( 'Authors', 'co-authors-plus-roles' ),
 			'CoAuthorsPlusRoles\coauthors_meta_box',
 			get_post_type(),
 			apply_filters( 'coauthors_meta_box_context', 'normal' ),
@@ -101,8 +101,8 @@ function coauthors_meta_box( $post ) {
 	}
 	// -- end copypasta
 
-	echo '<h2 style="margin-bottom:0">' . __( 'Credits', 'co-authors-plus' ) . '</h2>';
-	echo '<p>' . __( 'Click on an author to change them. Drag to change their order. Click on <b>Remove</b> to remove them.', 'co-authors-plus' ) . '</p>';
+	echo '<h2 style="margin-bottom:0">' . __( 'Credits', 'co-authors-plus-roles' ) . '</h2>';
+	echo '<p>' . __( 'Click on an author to change them. Drag to change their order. Click on <b>Remove</b> to remove them.', 'co-authors-plus-roles' ) . '</p>';
 
 	wp_nonce_field( 'coauthors_save', 'edit_coauthorsplus_roles_nonce' );
 
@@ -117,7 +117,7 @@ function coauthors_meta_box( $post ) {
 	echo '</ul>';
 
 	echo '<h4><a class="hide-if-no-js" href="#coauthor-add" id="coauthor-add-toggle">'
-		. __( '+ Add New Contributor', 'co-authors-plus' ) . '</a></h4>';
+		. __( '+ Add New Contributor', 'co-authors-plus-roles' ) . '</a></h4>';
 
 }
 
@@ -211,9 +211,9 @@ function enqueue_scripts() {
 	wp_localize_script( 'coauthor-select', 'coauthorsL10n',
 		array(
 			'title' => __( 'Insert/edit contributor', 'co-authors-plus-roles' ),
-			'update' => __( 'Update' ),
+			'update' => __( 'Update', 'co-authors-plus-roles' ),
 			'save' => __( 'Add Contributor', 'co-authors-plus-roles' ),
-			'noMatchesFound' => __( 'No results found.' )
+			'noMatchesFound' => __( 'No results found.', 'co-authors-plus-roles' )
 		)
 	);
 }
@@ -241,7 +241,6 @@ function coauthor_select_dialog() {
 			<div id="coauthor-select">
 				<div id="coauthor-options">
 					<p class="howto"><?php _e( 'Choose the role for this contributor:', 'coauthors-plus-roles' ); ?></p>
-
 					<select id="coauthor-select-role" name="coauthor-select-role">
 						<option value=""><?php _e( 'Choose a role', 'coauthors-plus-roles' ); ?></option>
 					<?php $roles_available = apply_filters( 'coauthors_author_roles', get_author_roles(), $post_id );

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -54,7 +54,7 @@ function add_meta_boxes() {
 
 
 /**
- * Outputs the HTML markup for the Contributors meta box.
+ * Outputs the HTML markup for the Authors meta box.
  *
  *
  */
@@ -101,7 +101,7 @@ function coauthors_meta_box( $post ) {
 	}
 	// -- end copypasta
 
-	echo '<h2 style="margin-bottom:0">' . __( 'Credits', 'co-authors-plus-roles' ) . '</h2>';
+	echo '<h2 style="margin-bottom:0">' . __( 'Author(s)', 'co-authors-plus-roles' ) . '</h2>';
 	echo '<p>' . __( 'Click on an author to change them. Drag to change their order. Click on <b>Remove</b> to remove them.', 'co-authors-plus-roles' ) . '</p>';
 
 	wp_nonce_field( 'coauthors_save', 'edit_coauthorsplus_roles_nonce' );
@@ -117,7 +117,7 @@ function coauthors_meta_box( $post ) {
 	echo '</ul>';
 
 	echo '<h4><a class="hide-if-no-js" href="#coauthor-add" id="coauthor-add-toggle">'
-		. __( '+ Add New Contributor', 'co-authors-plus-roles' ) . '</a></h4>';
+		. __( '+ Add New Author', 'co-authors-plus-roles' ) . '</a></h4>';
 
 }
 
@@ -210,9 +210,9 @@ function enqueue_scripts() {
 	);
 	wp_localize_script( 'coauthor-select', 'coauthorsL10n',
 		array(
-			'title' => __( 'Insert/edit contributor', 'co-authors-plus-roles' ),
+			'title' => __( 'Insert/edit author', 'co-authors-plus-roles' ),
 			'update' => __( 'Update', 'co-authors-plus-roles' ),
-			'save' => __( 'Add Contributor', 'co-authors-plus-roles' ),
+			'save' => __( 'Add Author', 'co-authors-plus-roles' ),
 			'noMatchesFound' => __( 'No results found.', 'co-authors-plus-roles' )
 		)
 	);

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -101,7 +101,6 @@ function coauthors_meta_box( $post ) {
 	}
 	// -- end copypasta
 
-	echo '<h2 style="margin-bottom:0">' . __( 'Author(s)', 'co-authors-plus-roles' ) . '</h2>';
 	echo '<p>' . __( 'Click on an author to change them. Drag to change their order. Click on <b>Remove</b> to remove them.', 'co-authors-plus-roles' ) . '</p>';
 
 	wp_nonce_field( 'coauthors_save', 'edit_coauthorsplus_roles_nonce' );

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -351,7 +351,7 @@ function ajax_search_coauthors() {
 	$coauthors = search_coauthors( $search, $post_ID );
 
 	if ( $coauthors )
-		wp_send_json( array_values( $coauthors ) );
+		wp_send_json_success( array_values( $coauthors ) );
 	else
 		wp_send_json_error( 'No authors were found.' );
 

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -213,7 +213,9 @@ function enqueue_scripts() {
 			'title' => __( 'Insert/edit author', 'co-authors-plus-roles' ),
 			'update' => __( 'Update', 'co-authors-plus-roles' ),
 			'save' => __( 'Add Author', 'co-authors-plus-roles' ),
-			'noMatchesFound' => __( 'No results found.', 'co-authors-plus-roles' )
+			'noMatchesFound' => __( 'No results found.', 'co-authors-plus-roles' ),
+			'addNewAuthorHeader' => __( 'Add new author to post', 'coauthors-plus-roles' ),
+			'editExistingAuthorHeader' => __( 'Edit author on post', 'coauthors-plus-roles' )
 		)
 	);
 }
@@ -233,7 +235,7 @@ function coauthor_select_dialog() {
 		<?php wp_nonce_field( 'coauthor-select', '_coauthor_select_nonce', false ); ?>
 		<input type="hidden" id="coauthor-post-id" value="<?php echo $post_id; ?>" />
 			<div id="coauthor-select-modal-title">
-				<?php _e( 'Add new contributor to post', 'coauthors-plus-roles' ) ?>
+				<span id="coauthor-select-header"></span>
 				<button type="button" id="coauthor-select-close">
 					<span class="screen-reader-text"><?php _e( 'Close' ); ?></span>
 				</button>

--- a/includes/author-roles-posts-relationships.php
+++ b/includes/author-roles-posts-relationships.php
@@ -18,7 +18,7 @@ namespace CoAuthorsPlusRoles;
  * @param object|string $author_role Term or slug of contributor role to set. Defaults to "byline" if empty
  * @return bool True on success, false on failure (if any of the inputs are not acceptable).
  */
-function set_contributor_on_post( $post_id, $author, $author_role = false ) {
+function set_author_on_post( $post_id, $author, $author_role = false ) {
 	global $coauthors_plus, $wpdb;
 
 	if ( is_object( $post_id ) && isset( $post_id->ID ) )
@@ -65,7 +65,7 @@ function set_contributor_on_post( $post_id, $author, $author_role = false ) {
  * @param object|string $author WP_User object, or nicename/user_login/slug
  * @return bool True on success, false on failure (if any of the inputs are not acceptable).
  */
-function remove_contributor_from_post( $post_id, $author ) {
+function remove_author_from_post( $post_id, $author ) {
 	global $coauthors_plus, $wpdb;
 
 	if ( is_object( $post_id ) && isset( $post_id->ID ) )

--- a/includes/author-roles.php
+++ b/includes/author-roles.php
@@ -46,7 +46,10 @@ function register_author_role( $slug, $args = array() ) {
 		'labels' => array(
 			'name_user_role_singular' => $name,
 			'name_user_role_plural' => $name,
-			'post_relationship_by' => "$name by %s"
+			'post_relationship_by' => sprintf(
+				_x( '%s by %s', 'role by author: Illustrated by Alice', 'co-authors-plus-roles' ),
+				$name, '%s'
+			)
 		)
 	);
 

--- a/includes/author-roles.php
+++ b/includes/author-roles.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Registers the post type for "Contributor Roles", and provides a basic API
+ * Registers the post type for "Author Roles", and provides a basic API
  * for adding and removing roles.
  *
  */
@@ -32,7 +32,7 @@ add_action( 'init', '\CoAuthorsPlusRoles\create_author_roles', 0 );
  *
  * @param string $slug Slug to use for this contributor role
  * @param array $args Overrides to define this role
- * @return object the created WP_Contributor_Role object
+ * @return object the created WP_Author_Role object
  */
 function register_author_role( $slug, $args = array() ) {
 	global $_wp_author_roles;
@@ -76,7 +76,7 @@ function remove_author_role( $slug ) {
  *
  * @param string $slug Slug of role to remove
  * @param array $args Overrides to define this role
- * @return object the created WP_Contributor_Role object
+ * @return object the created WP_Author_Role object
  */
 function modify_author_role( $slug, $name, $args ) {
 	register_author_role( $slug, $name, $args );
@@ -99,7 +99,7 @@ function get_author_roles() {
  *
  * Useful for retrieving labels or settings attached to roles.
  *
- * @return object Contributor role object
+ * @return object Author role object
  */
 function get_author_role( $slug ) {
 	global $_wp_author_roles;

--- a/includes/author-roles.php
+++ b/includes/author-roles.php
@@ -42,11 +42,11 @@ function register_author_role( $slug, $args = array() ) {
 	$defaults = array(
 		'slug' => $slug,
 		'byline' => false,
-		'name' => __( $name ),
+		'name' => $name,
 		'labels' => array(
-			'name_user_role_singular' => __( $name ),
-			'name_user_role_plural' => __( $name ),
-			'post_relationship_by' => __( "$name by %s" )
+			'name_user_role_singular' => $name,
+			'name_user_role_plural' => $name,
+			'post_relationship_by' => "$name by %s"
 		)
 	);
 

--- a/includes/default-author-roles.php
+++ b/includes/default-author-roles.php
@@ -20,33 +20,33 @@ function register_default_author_roles() {
 	register_author_role( 'author',
 		array(
 			'byline' => true,
-			'name' => __( 'Author' ),
+			'name' => __( 'Author', 'co-authors-plus-roles' ),
 			'labels' => array(
-				'name_user_role_singular' => __( 'Author' ),
-				'name_user_role_plural' => __( 'Authors' ),
-				'post_relationship_by' => __( 'by %s' )
+				'name_user_role_singular' => __( 'Author', 'co-authors-plus-roles' ),
+				'name_user_role_plural' => __( 'Authors', 'co-authors-plus-roles' ),
+				'post_relationship_by' => __( 'by %s', 'co-authors-plus-roles' )
 			)
 		)
 	);
 	register_author_role( 'contributing-author',
 		array(
 			'byline' => false,
-			'name' => __( 'Contributing Author' ),
+			'name' => __( 'Contributing Author', 'co-authors-plus-roles' ),
 			'labels' => array(
-				'name_user_role_singular' => __( 'Contributing Author' ),
-				'name_user_role_plural' => __( 'Contributing Authors' ),
-				'post_relationship_by' => __( 'Additional Reporting by %s' )
+				'name_user_role_singular' => __( 'Contributing Author', 'co-authors-plus-roles' ),
+				'name_user_role_plural' => __( 'Contributing Authors', 'co-authors-plus-roles' ),
+				'post_relationship_by' => __( 'Additional Reporting by %s', 'co-authors-plus-roles' )
 			)
 		)
 	);
 	register_author_role( 'photographer',
 		array(
 			'byline' => false,
-			'name' => __( 'Photographer' ),
+			'name' => __( 'Photographer', 'co-authors-plus-roles' ),
 			'labels' => array(
-				'name_user_role_singular' => __( 'Photographer' ),
-				'name_user_role_plural' => __( 'Photographers' ),
-				'post_relationship_by' => __( 'Photography by %s' )
+				'name_user_role_singular' => __( 'Photographer', 'co-authors-plus-roles' ),
+				'name_user_role_plural' => __( 'Photographers', 'co-authors-plus-roles' ),
+				'post_relationship_by' => __( 'Photography by %s', 'co-authors-plus-roles' )
 			)
 		)
 	);

--- a/includes/js/coauthors.js
+++ b/includes/js/coauthors.js
@@ -23,10 +23,12 @@ var coauthorsSelector, coauthorsSortable;
 			currentlyEditing = thisLi;
 
 			coauthorsSelector.open();
+
 			inputs.role.val( link.data('role') );
 			inputs.authorId.val( link.data('author-id') );
 			inputs.search.val( link.data('author-name') );
 
+			inputs.search.trigger('keyup');
 		},
 
 		init: function() {
@@ -51,6 +53,7 @@ var coauthorsSelector, coauthorsSortable;
 			inputs.backdrop = $( '#coauthor-select-backdrop' );
 			inputs.submit = $( '#coauthor-select-submit' );
 			inputs.close = $( '#coauthor-select-close' );
+			inputs.header = $( '#coauthor-select-header' );
 
 			// Inputs
 			inputs.role = $( '#coauthor-select-role' );
@@ -109,15 +112,26 @@ var coauthorsSelector, coauthorsSortable;
 
 			coauthorsSelector.range = null;
 
+			inputs.header.text( function() {
+				return currentlyEditing ? 
+					coauthorsL10n.editExistingAuthorHeader : 
+					coauthorsL10n.addNewAuthorHeader;
+			});
+
 			inputs.wrap.show();
 			inputs.backdrop.show();
 
 			coauthorsSelector.refresh();
-			$( document ).trigger( 'coauthors-select-open', inputs.wrap );
 
+			$( document ).trigger( 'coauthors-select-open', inputs.wrap );
 		},
 
 		refresh: function() {
+
+			// Reset each of the inputs
+			inputs.role.val();
+			inputs.authorId.val();
+			inputs.search.val();
 
 			// Refresh rivers (clear links, check visibility)
 			rivers.search.refresh();

--- a/includes/js/coauthors.js
+++ b/includes/js/coauthors.js
@@ -409,13 +409,13 @@ var coauthorsSelector, coauthorsSortable;
 			var list = '', alt = true, classes = '',
 				firstPage = params.page == 1;
 
-			if ( ! results ) {
+			if ( typeof results.success === 'undefined' || ! results.success ) {
 				if ( firstPage ) {
 					list += '<li class="unselectable no-matches-found"><span class="item-title"><em>' +
 						coauthorsL10n.noMatchesFound + '</em></span></li>';
 				}
 			} else {
-				$.each( results, function() {
+				$.each( results.data, function() {
 					classes = alt ? 'alternate' : '';
 					classes += this.post_title ? '' : ' no-title';
 					list += classes ? '<li class="' + classes + '">' : '<li>';

--- a/tests/test-manage-contributors.php
+++ b/tests/test-manage-contributors.php
@@ -5,14 +5,14 @@
  * These tests mirror the tests in test-manage-coauthors.php, but also include roles.
  */
 
-class Test_Manage_ContributorRoles extends CoAuthorsPlusRoles_TestCase {
+class Test_Manage_Author_Roles extends CoAuthorsPlusRoles_TestCase {
 
 	/**
 	 * Test registering, removing, and modifying a role.
 	 */
 	public function test_manage_author_roles() {
 
-		// The default contributor roles should be active initially.
+		// The default author roles should be active initially.
 		$roles = get_author_roles();
 		$this->assertEquals( 3, count( $roles ) );
 		$this->assertEquals( 'Author', $roles['author']->name );
@@ -79,7 +79,7 @@ class Test_Manage_ContributorRoles extends CoAuthorsPlusRoles_TestCase {
 
 		$guest_author_user_object = $coauthors_plus->get_coauthor_by( 'id', $guest_author_1 );
 
-		// Setting a guest author as a contributor on a post should include
+		// Setting a guest author as an author on a post should include
 		// them in the get_coauthors() response for that post.
 		\CoAuthorsPlusRoles\set_contributor_on_post( $post, $guest_author_user_object );
 		$all_credits_on_post = CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'any' ) );

--- a/tests/test-manage-contributors.php
+++ b/tests/test-manage-contributors.php
@@ -37,7 +37,7 @@ class Test_Manage_Author_Roles extends CoAuthorsPlusRoles_TestCase {
 		$this->assertEquals( $this->author1, get_post( $this->author1_post1 )->post_author );
 
 		// Add a coauthor in a non-byline role. Should not be returned by get_coauthors.
-		\CoAuthorsPlusRoles\set_contributor_on_post(
+		\CoAuthorsPlusRoles\set_author_on_post(
 			$this->author1_post1, $this->editor1, 'contributing-author'
 		);
 		$coauthors = get_coauthors( $this->author1_post1 );
@@ -49,7 +49,7 @@ class Test_Manage_Author_Roles extends CoAuthorsPlusRoles_TestCase {
 		$this->assertEquals( 2, count( $all_credits ) );
 
 		// Remove a co-author from a post
-		\CoAuthorsPlusRoles\remove_contributor_from_post( $this->author1_post1, $this->editor1 );
+		\CoAuthorsPlusRoles\remove_author_from_post( $this->author1_post1, $this->editor1 );
 		$all_credits = CoAuthorsPlusRoles\get_coauthors( $this->author1_post1, array( 'author_role' => 'any' ) );
 		$this->assertEquals( 1, count( $all_credits ) );
 
@@ -81,7 +81,7 @@ class Test_Manage_Author_Roles extends CoAuthorsPlusRoles_TestCase {
 
 		// Setting a guest author as an author on a post should include
 		// them in the get_coauthors() response for that post.
-		\CoAuthorsPlusRoles\set_contributor_on_post( $post, $guest_author_user_object );
+		\CoAuthorsPlusRoles\set_author_on_post( $post, $guest_author_user_object );
 		$all_credits_on_post = CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'any' ) );
 		$this->assertContains( $guest_author_1, wp_list_pluck( $all_credits_on_post, 'ID' ) );
 
@@ -91,7 +91,7 @@ class Test_Manage_Author_Roles extends CoAuthorsPlusRoles_TestCase {
 
 		// Setting a guest author as a non-byline role on a post should also include
 		// them in the get_coauthors() response for that post.
-		\CoAuthorsPlusRoles\set_contributor_on_post( $post, $guest_author_2 );
+		\CoAuthorsPlusRoles\set_author_on_post( $post, $guest_author_2 );
 		$all_credits_on_post = CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'any' ) );
 		$this->assertContains( $guest_author_2, wp_list_pluck( $all_credits_on_post, 'ID' ) );
 


### PR DESCRIPTION
I'm dealing with the easy issues first :smile: 

This PR addresses a few of the open issues:

- standardizes on "Authors" as nomenclature, vs the several different names which were used before,
- marks all translatable strings for i18n, with `co-authors-plus-roles` as the textdomain,
- updates the modal title depending on whether the user is adding a new author or updating an existing one,
- fixes the JS error on editing an existing author (caused by the ajax endpoint returning data in a different format than expected).