### PR TITLE
Store coauthors by user_nicename, not by ID

### DIFF
--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -343,16 +343,12 @@ function search_coauthors( $search_term, $post_ID ) {
 	}
 
 	if ( isset( $post_ID ) && intval( $post_ID ) > 0 ) {
-		$existing = get_coauthors( $post_ID );
+		$existing_authors = get_coauthors( $post_ID, array( 'author_role' => 'any' ) );
 
-		// XXX: I suspect, but haven't measured, that this comparator function
-		// is ridiculously slow. Investigate refactoring.
-		$coauthors = array_udiff( $coauthors, $existing,
+		// Remove array elements from $coauthors that are identical to existing authors.
+		$coauthors = array_udiff( $coauthors, $existing_authors,
 			function( $author, $existing ) {
-				if ( (int) $author->user_nicename == (int) $existing->user_nicename ) {
-					return 0; // zero represents equality here, like in compare. PHP why?
-				}
-				return 1;
+				return strcmp( $author->user_nicename, $existing->user_nicename );
 			}
 		);
 	}

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -114,8 +114,9 @@ function coauthors_meta_box( $post ) {
 	// have that field if the author hasn't been saved yet.
 	$coauthors = array_map(
 		function($author) {
-			if ( ! isset( $author->author_role ) )
+			if ( ! isset( $author->author_role ) ) {
 				$author->author_role = '';
+			}
 			return $author;
 		}, $coauthors );
 
@@ -152,11 +153,13 @@ function coauthors_meta_box( $post ) {
  *                                 Passing this second parameter will set it on the coauthor.
  */
 function template_coauthor_sortable( $coauthor, $author_role = null ) {
-	if ( $author_role )
+	if ( $author_role ) {
 		$coauthor->author_role = $author_role;
+	}
 
-	if ( ! isset( $coauthor->type ) )
+	if ( ! isset( $coauthor->type ) ) {
 		$coauthor->type = 'WP USER';
+	}
 
 	// The format in which these values are posted.
 	$coauthor_input_value = "{$coauthor->user_nicename}|||{$coauthor->author_role}";
@@ -206,8 +209,9 @@ function ajax_template_coauthor_sortable() {
 	$coauthor = $coauthors_plus->get_coauthor_by( 'id', intval( $_REQUEST['authorId'] ) );
 	$role = get_author_role( $_REQUEST['authorRole'] );
 
-	if ( ! $coauthor || ! $role )
+	if ( ! $coauthor || ! $role ) {
 		wp_die( 'Missing required information.' );
+	}
 
 	$coauthor->author_role = $role->slug;
 
@@ -242,8 +246,9 @@ function coauthor_select_dialog() {
 	global $post_ID, $post;
 
 	$post_id = $post_ID;
-	if ( ! isset( $post_id ) && isset( $post ) )
+	if ( ! isset( $post_id ) && isset( $post ) ) {
 		$post_id = $post->ID;
+	}
 
 		?>
 	<div id="coauthor-select-backdrop" style="display: none"></div>
@@ -331,10 +336,11 @@ function coauthor_select_dialog() {
 function search_coauthors( $search_term, $post_ID ) {
 	global $coauthors_plus;
 
-	if ( isset( $search_term ) && $search_term )
+	if ( isset( $search_term ) && $search_term ) {
 		$coauthors = $coauthors_plus->search_authors( $search_term );
-	else
+	} else {
 		$coauthors = get_top_authors();
+	}
 
 	if ( isset( $post_ID ) && intval( $post_ID ) > 0 ) {
 		$existing = get_coauthors( $post_ID );
@@ -343,8 +349,9 @@ function search_coauthors( $search_term, $post_ID ) {
 		// is ridiculously slow. Investigate refactoring.
 		$coauthors = array_udiff( $coauthors, $existing,
 			function( $author, $existing ) {
-				if ( (int) $author->user_nicename == (int) $existing->user_nicename )
+				if ( (int) $author->user_nicename == (int) $existing->user_nicename ) {
 					return 0; // zero represents equality here, like in compare. PHP why?
+				}
 				return 1;
 			}
 		);
@@ -368,10 +375,11 @@ function ajax_search_coauthors() {
 	$post_ID = isset( $_REQUEST['postId'] ) ? intval( $_REQUEST['postId'] ) : false;
 	$coauthors = search_coauthors( $search, $post_ID );
 
-	if ( $coauthors )
+	if ( $coauthors ) {
 		wp_send_json( array_values( $coauthors ) );
-	else
+	} else {
 		wp_send_json_error( 'No authors were found.' );
+	}
 
 	die(0);
 }
@@ -399,13 +407,15 @@ function get_top_authors() {
 		)
 	);
 
-	if ( ! $all_published_authors )
+	if ( ! $all_published_authors ) {
 		return false;
+	}
 
 	$coauthors = array();
 
-	foreach ( $all_published_authors as $author_term )
+	foreach ( $all_published_authors as $author_term ) {
 		$coauthors[] = $coauthors_plus->get_coauthor_by( 'user_nicename', $author_term );
+	}
 
 	// Because coauthors can include duplicates (in the case of linked accounts), uniq it first.
 	return array_unique( $coauthors, SORT_REGULAR );
@@ -422,8 +432,9 @@ function update_coauthors_on_post( $post_id, $new_coauthors ) {
 	global $coauthors_plus;
 
 	$post = get_post( $post_id );
-	if ( ! $coauthors_plus->is_post_type_enabled( $post->post_type ) )
+	if ( ! $coauthors_plus->is_post_type_enabled( $post->post_type ) ) {
 		return;
+	}
 
 	if ( $new_coauthors && is_array( $new_coauthors ) ) {
 		// XXX This should diff against the already added coauthors, or alternately just wipe them every time.
@@ -448,14 +459,17 @@ function update_coauthors_on_post( $post_id, $new_coauthors ) {
 function action_update_coauthors_on_post( $post_id, $post ) {
 	global $coauthors_plus;
 
-	if ( ! $post_id && isset( $_POST['post_ID'] ) )
+	if ( ! $post_id && isset( $_POST['post_ID'] ) ) {
 		$post_id = intval( $_POST['post_ID'] );
+	}
 
-	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
+	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 		return;
+	}
 
-	if ( empty( $_POST['coauthors'] ) )
+	if ( empty( $_POST['coauthors'] ) ) {
 		return;
+	}
 
 	if ( $coauthors_plus->current_user_can_set_authors( $post ) ) {
 		// if current_user_can_set_authors and nonce valid
@@ -471,8 +485,9 @@ function action_update_coauthors_on_post( $post_id, $post ) {
 		if ( ! $coauthors_plus->has_author_terms( $post_id ) ) {
 			$user = get_userdata( $post->post_author );
 
-			if ( $user )
+			if ( $user ) {
 				set_contributor_on_post( $post_id, $user->user_login );
+			}
 		}
 	}
 }

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -424,10 +424,6 @@ function update_coauthors_on_post( $post_id, $new_coauthors ) {
 			// posted string into the expected types here.
 			list( $author, $role ) = explode( '|||', $coauthor );
 			$author = $coauthors_plus->get_coauthor_by( 'user_nicename', $author );
-			$role = get_author_role( $role );
-
-			var_dump( $author, $role );
-
 			set_contributor_on_post( $post_id, $author, $role );
 
 		}

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -104,10 +104,21 @@ function coauthors_meta_box( $post ) {
 				$coauthors[] = $default_user;
 			}
 		}
+
 	} else {
 		$coauthors = get_coauthors( $post_id, array( 'author_role' => 'any' ) );
 	}
 	// -- end copypasta
+
+	// Extend the coauthors as returned from Co-Authors Plus with the 'author_role' field, as it won't
+	// have that field if the author hasn't been saved yet.
+	$coauthors = array_map(
+		function($author) {
+			if ( ! isset( $author->author_role ) )
+				$author->author_role = '';
+			return $author;
+		}, $coauthors );
+
 
 	echo '<h2 style="margin-bottom:0">' . __( 'Credits', 'co-authors-plus' ) . '</h2>';
 	echo '<p>' . __( 'Click on an author to change them. Drag to change their order. Click on <b>Remove</b> to remove them.', 'co-authors-plus' ) . '</p>';

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -148,9 +148,9 @@ function template_coauthor_sortable( $coauthor, $author_role = null ) {
 		$coauthor->type = 'WP USER';
 
 	// The format in which these values are posted.
-	$coauthor_input_value = "{$coauthor->ID}|||{$coauthor->author_role}";
+	$coauthor_input_value = "{$coauthor->user_nicename}|||{$coauthor->author_role}";
 	?>
-	<li id="menu-item-<?php echo $coauthor->ID; ?>" class="menu-item coauthor-sortable">
+	<li id="menu-item-<?php echo $coauthor->user_nicename; ?>" class="menu-item coauthor-sortable">
 		<dl class="menu-item-bar">
 			<dt class="menu-item-handle">
 				<span class="author-avatar">
@@ -166,7 +166,7 @@ function template_coauthor_sortable( $coauthor, $author_role = null ) {
 					<a class="edit-coauthor"
 						data-author-name="<?php echo $coauthor->display_name; ?>"
 						data-role="<?php echo $author_role; ?>"
-						data-author-id="<?php echo $coauthor->ID; ?>"
+						data-author-id="<?php echo $coauthor->user_nicename; ?>"
 						><?php echo $author_role; ?></a>
 				</span>
 				<span class="author-controls sortable-flex-section">
@@ -332,7 +332,7 @@ function search_coauthors( $search_term, $post_ID ) {
 		// is ridiculously slow. Investigate refactoring.
 		$coauthors = array_udiff( $coauthors, $existing,
 			function( $author, $existing ) {
-				if ( (int) $author->ID == (int) $existing->ID )
+				if ( (int) $author->user_nicename == (int) $existing->user_nicename )
 					return 0; // zero represents equality here, like in compare. PHP why?
 				return 1;
 			}
@@ -423,8 +423,10 @@ function update_coauthors_on_post( $post_id, $new_coauthors ) {
 			// some type checking of its parameters, so we coerce the
 			// posted string into the expected types here.
 			list( $author, $role ) = explode( '|||', $coauthor );
-			$author = intval( $author );
+			$author = $coauthors_plus->get_coauthor_by( 'user_nicename', $author );
 			$role = get_author_role( $role );
+
+			var_dump( $author, $role );
 
 			set_contributor_on_post( $post_id, $author, $role );
 

--- a/includes/author-roles-posts-relationships.php
+++ b/includes/author-roles-posts-relationships.php
@@ -21,27 +21,32 @@ namespace CoAuthorsPlusRoles;
 function set_contributor_on_post( $post_id, $author, $author_role = false ) {
 	global $coauthors_plus, $wpdb;
 
-	if ( is_object( $post_id ) && isset( $post_id->ID ) )
+	if ( is_object( $post_id ) && isset( $post_id->ID ) ) {
 		$post_id = $post_id->ID;
+	}
 
 	$post_id = intval( $post_id );
 
-	if ( is_string( $author ) && intval( $author ) != $author )
+	if ( is_string( $author ) && intval( $author ) != $author ) {
 		$author = $coauthors_plus->get_coauthor_by( 'user_nicename', $author );
-	else if ( is_int( $author ) )
+	} else if ( is_int( $author ) ) {
 		$author = $coauthors_plus->get_coauthor_by( 'id', $author );
+	}
 
-	if ( ! isset( $author->user_nicename ) )
+	if ( ! isset( $author->user_nicename ) ) {
 		return false;
+	}
 
 	// Only create the byline term if the contributor role is:
 	//  - one of the byline roles, as set in register_author_role(), or
 	//  - unset, meaning they should default to primary author role.
-	if ( ! $author_role || in_array( $author_role, byline_roles() ) )
+	if ( ! $author_role || in_array( $author_role, byline_roles() ) ) {
 		$coauthors_plus->add_coauthors( $post_id, array( $author->user_nicename ), true );
+	}
 
-	if ( ! $post_id || ! $author )
+	if ( ! $post_id || ! $author ) {
 		return false;
+	}
 
 	$drop_existing_role = $wpdb->query(
 		$wpdb->prepare(
@@ -54,8 +59,9 @@ function set_contributor_on_post( $post_id, $author, $author_role = false ) {
 		$author_role = get_author_role( $author_role );
 	}
 
-	if ( ! $author_role )
+	if ( ! $author_role ) {
 		return false;
+	}
 
 	update_post_meta( $post_id, 'cap-' . $author_role->slug, $author->user_nicename );
 }
@@ -71,16 +77,19 @@ function set_contributor_on_post( $post_id, $author, $author_role = false ) {
 function remove_contributor_from_post( $post_id, $author ) {
 	global $coauthors_plus, $wpdb;
 
-	if ( is_object( $post_id ) && isset( $post_id->ID ) )
+	if ( is_object( $post_id ) && isset( $post_id->ID ) ) {
 		$post_id = $post_id->ID;
+	}
 
 	$post_id = intval( $post_id );
 
-	if ( is_string( $author ) )
+	if ( is_string( $author ) ) {
 		$author = $coauthors_plus->get_coauthor_by( 'user_nicename', $author );
+	}
 
-	if ( is_int( $author ) )
+	if ( is_int( $author ) ) {
 		$author = $coauthors_plus->get_coauthor_by( 'id', $author );
+	}
 
 	// Remove byline term from post: Start by getting the author terms on the post.
 	$existing_authors = wp_get_object_terms( $post_id, $coauthors_plus->coauthor_taxonomy, array( 'fields' => 'slugs' ) );

--- a/includes/author-roles.php
+++ b/includes/author-roles.php
@@ -104,11 +104,13 @@ function get_author_roles() {
 function get_author_role( $slug ) {
 	global $_wp_author_roles;
 
-	if ( strpos( $slug, 'cap-' ) === 0 )
+	if ( strpos( $slug, 'cap-' ) === 0 ) {
 		$slug = strstr( $slug, 4 );
+	}
 
-	if ( ! isset( $_wp_author_roles[ $slug ] ) )
+	if ( ! isset( $_wp_author_roles[ $slug ] ) ) {
 		return false;
+	}
 
 	return $_wp_author_roles[ $slug ];
 }

--- a/includes/default-author-roles.php
+++ b/includes/default-author-roles.php
@@ -28,7 +28,7 @@ function register_default_author_roles() {
 			)
 		)
 	);
-	register_author_role( 'contributing-author',
+	register_author_role( 'contributor',
 		array(
 			'byline' => false,
 			'name' => __( 'Contributing Author' ),

--- a/includes/js/coauthors.js
+++ b/includes/js/coauthors.js
@@ -171,11 +171,12 @@ var coauthorsSelector, coauthorsSortable;
 				};
 
 			$.post( ajaxurl, query, function( r ) {
-				if ( currentlyEditing )
+				if ( currentlyEditing ) {
 					currentlyEditing.html( r )
-				else 
+				} else {
 					coauthorsSortable.list.append( r );
-				
+				}
+
 			});
 			this.close();
 
@@ -194,8 +195,9 @@ var coauthorsSelector, coauthorsSortable;
 				rivers.search.show();
 
 				// Don't search if the keypress didn't change the title.
-				if ( coauthorsSelector.lastSearch == search )
+				if ( coauthorsSelector.lastSearch == search ) {
 					return;
+				}
 
 				coauthorsSelector.lastSearch = search;
 				waiting = t.parent().find('.spinner').show();
@@ -269,19 +271,22 @@ var coauthorsSelector, coauthorsSortable;
 		delayedCallback: function( func, delay ) {
 			var timeoutTriggered, funcTriggered, funcArgs, funcContext;
 
-			if ( ! delay )
+			if ( ! delay ) {
 				return func;
+			}
 
 			setTimeout( function() {
-				if ( funcTriggered )
+				if ( funcTriggered ) {
 					return func.apply( funcContext, funcArgs );
+				}
 				// Otherwise, wait.
 				timeoutTriggered = true;
 			}, delay );
 
 			return function() {
-				if ( timeoutTriggered )
+				if ( timeoutTriggered ) {
 					return func.apply( this, arguments );
+				}
 				// Otherwise, wait.
 				funcArgs = arguments;
 				funcContext = this;
@@ -329,8 +334,9 @@ var coauthorsSelector, coauthorsSortable;
 		select: function( li, event ) {
 			var liHeight, elHeight, liTop, elTop;
 
-			if ( li.hasClass( 'unselectable' ) || li == this.selected )
+			if ( li.hasClass( 'unselectable' ) || li == this.selected ) {
 				return;
+			}
 
 			this.deselect();
 			this.selected = li.addClass( 'selected' );
@@ -349,43 +355,50 @@ var coauthorsSelector, coauthorsSortable;
 			this.element.trigger( 'coauthors-river-select', [ li, event, this ] );
 		},
 		deselect: function() {
-			if ( this.selected )
+			if ( this.selected ) {
 				this.selected.removeClass( 'selected' );
+			}
 			this.selected = false;
 		},
 		prev: function() {
-			if ( ! this.visible )
+			if ( ! this.visible ) {
 				return;
+			}
 
 			var to;
 			if ( this.selected ) {
 				to = this.selected.prev( 'li' );
-				if ( to.length )
+				if ( to.length ) {
 					this.select( to );
+				}
 			}
 		},
 		next: function() {
-			if ( ! this.visible )
+			if ( ! this.visible ) {
 				return;
+			}
 
 			var to = this.selected ? this.selected.next( 'li' ) : $( 'li:not(.unselectable):first', this.element );
-			if ( to.length )
+			if ( to.length ) {
 				this.select( to );
+			}
 		},
 		ajax: function( callback ) {
 			var self = this,
 				delay = this.query.page == 1 ? 0 : coauthorsSelector.minRiverAJAXDuration,
 				response = coauthorsSelector.delayedCallback( function( results, params ) {
 					self.process( results, params );
-					if ( callback )
+					if ( callback ) {
 						callback( results, params );
+					}
 				}, delay );
 
 			this.query.ajax( response );
 		},
 		change: function( search ) {
-			if ( this.query && this._search == search )
+			if ( this.query && this._search == search ) {
 				return;
+			}
 
 			this._search = search;
 			this.query = new Query( search );
@@ -420,15 +433,17 @@ var coauthorsSelector, coauthorsSortable;
 				el = this.element,
 				bottom = el.scrollTop() + el.height();
 
-			if ( ! this.query.ready() || bottom < this.contentHeight.height() - coauthorsSelector.riverBottomThreshold )
+			if ( ! this.query.ready() || bottom < this.contentHeight.height() - coauthorsSelector.riverBottomThreshold ) {
 				return;
+			}
 
 			setTimeout(function() {
 				var newTop = el.scrollTop(),
 					newBottom = newTop + el.height();
 
-				if ( ! self.query.ready() || newBottom < self.contentHeight.height() - coauthorsSelector.riverBottomThreshold )
+				if ( ! self.query.ready() || newBottom < self.contentHeight.height() - coauthorsSelector.riverBottomThreshold ) {
 					return;
+				}
 
 				self.waiting.show();
 				el.scrollTop( newTop + self.waiting.outerHeight() );
@@ -460,8 +475,9 @@ var coauthorsSelector, coauthorsSortable;
 					'_ajax_coauthor_search_nonce' : inputs.nonce.val()
 				};
 
-			if ( this.search )
+			if ( this.search ) {
 				query.search = this.search;
+			}
 
 			this.querying = true;
 

--- a/includes/query.php
+++ b/includes/query.php
@@ -27,13 +27,15 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 
 	// Default to current post if $post_id is not set.
 	$post_id = (int)$post_id;
-	if ( ! $post_id && $post_ID )
+	if ( ! $post_id && $post_ID ) {
 		$post_id = $post_ID;
-	if ( ! $post_id && $post )
+	}
+	if ( ! $post_id && $post ) {
 		$post_id = $post->ID;
-
-	if ( ! $post_id )
+	}
+	if ( ! $post_id ) {
 		return;
+	}
 
 	// Querying for "bylines" (the default) should return the same results as in CAP
 	if ( $args['author_role'] === 'byline' ) {
@@ -58,8 +60,9 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 			} else {
 				$post_author = get_userdata( $wpdb->get_var( $wpdb->prepare( "SELECT post_author FROM $wpdb->posts WHERE ID = %d", $post_id ) ) );
 			}
-			if ( ! empty( $post_author ) )
+			if ( ! empty( $post_author ) ) {
 				$coauthors[] = $post_author;
+			}
 		} // the empty else case is because if we force guest authors, we don't ever care what value wp_posts.post_author has.
 	} else {
 		/*
@@ -109,15 +112,17 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 
 					// Since some authors may have also been added through postmeta, skip them here
 					// so as not to include duplicate authors in results.
-					if ( in_array( $coauthor_slug, wp_list_pluck( $coauthors, 'user_nicename' ) ) )
+					if ( in_array( $coauthor_slug, wp_list_pluck( $coauthors, 'user_nicename' ) ) ) {
 						continue;
+					}
 
 					$post_author = $coauthors_plus->get_coauthor_by( 'user_nicename', $coauthor_slug );
 					$post_author->author_role = 'byline';
 
 					// In case the user has been deleted while plugin was deactivated
-					if ( ! empty( $post_author ) )
+					if ( ! empty( $post_author ) ) {
 						$coauthors[] = $post_author;
+					}
 				}
 			}
 		}

--- a/includes/query.php
+++ b/includes/query.php
@@ -87,16 +87,16 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 		// Because $wpdb->prepare would add slashes to my IN() clause...
 		$meta_key_in = "( '" . implode( "','", array_map( 'esc_sql', $roles_meta_keys ) ) . "' )";
 
-		$coauthor_ids = $wpdb->get_results(
+		$coauthor_nicenames = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT * FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key IN {$meta_key_in};",
 				array( $post_id )
 			)
 		);
 
-		foreach ( $coauthor_ids as $coauthor_id ) {
-			$_coauthor = $coauthors_plus->get_coauthor_by( 'user_nicename', $coauthor_id->meta_value );
-			$_coauthor->author_role = strstr( $coauthor_id->meta_key, 4 );
+		foreach ( $coauthor_nicenames as $coauthor_nicename ) {
+			$_coauthor = $coauthors_plus->get_coauthor_by( 'user_nicename', $coauthor_nicename->meta_value );
+			$_coauthor->author_role = substr( $coauthor_nicename->meta_key, 4 );
 			$coauthors[] = $_coauthor;
 		}
 

--- a/includes/query.php
+++ b/includes/query.php
@@ -92,7 +92,7 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 		);
 
 		foreach ( $coauthor_ids as $coauthor_id ) {
-			$_coauthor = $coauthors_plus->get_coauthor_by( 'id', $coauthor_id->meta_value );
+			$_coauthor = $coauthors_plus->get_coauthor_by( 'user_nicename', $coauthor_id->meta_value );
 			$_coauthor->author_role = strstr( $coauthor_id->meta_key, 4 );
 			$coauthors[] = $_coauthor;
 		}

--- a/tests/test-manage-contributors.php
+++ b/tests/test-manage-contributors.php
@@ -29,16 +29,17 @@ class Test_Manage_ContributorRoles extends CoAuthorsPlusRoles_TestCase {
 	public function test_manage_author_roles_relationships() {
 		global $coauthors_plus;
 		$author1 = get_user_by( 'id', $this->author1 );
+		$editor1 = get_user_by( 'id', $this->editor1 );
 
 		// Setup: assign author1 as the only co-author (byline)
 		$coauthors_plus->add_coauthors(
-			$this->author1_post1, array( $author1->user_login ), false
+			$this->author1_post1, array( $author1->user_nicename ), false
 		);
 		$this->assertEquals( $this->author1, get_post( $this->author1_post1 )->post_author );
 
 		// Add a coauthor in a non-byline role. Should not be returned by get_coauthors.
 		\CoAuthorsPlusRoles\set_contributor_on_post(
-			$this->author1_post1, $this->editor1, 'contributing-author'
+			$this->author1_post1, $editor1, 'contributor'
 		);
 		$coauthors = get_coauthors( $this->author1_post1 );
 		$coauthors_this_plugin = CoAuthorsPlusRoles\get_coauthors( $this->author1_post1 );
@@ -74,14 +75,16 @@ class Test_Manage_ContributorRoles extends CoAuthorsPlusRoles_TestCase {
 		$all_contributors = CoAuthorsPlusRoles\get_top_authors();
 		$this->assertEquals( count( $all_contributors ), 3 );
 		$this->assertContains( $guest_author_1, wp_list_pluck( $all_contributors, 'ID' ) );
+		$this->assertContains( $guest_author_2, wp_list_pluck( $all_contributors, 'ID' ) );
 
 		$post = $this->author1_post1;
 
-		$guest_author_user_object = $coauthors_plus->get_coauthor_by( 'id', $guest_author_1 );
+		$guest_author_1_user_object = $coauthors_plus->get_coauthor_by( 'id', $guest_author_1 );
+		$guest_author_2_user_object = $coauthors_plus->get_coauthor_by( 'id', $guest_author_2 );
 
 		// Setting a guest author as a contributor on a post should include
 		// them in the get_coauthors() response for that post.
-		\CoAuthorsPlusRoles\set_contributor_on_post( $post, $guest_author_user_object );
+		\CoAuthorsPlusRoles\set_contributor_on_post( $post, $guest_author_1_user_object );
 		$all_credits_on_post = CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'any' ) );
 		$this->assertContains( $guest_author_1, wp_list_pluck( $all_credits_on_post, 'ID' ) );
 
@@ -91,7 +94,7 @@ class Test_Manage_ContributorRoles extends CoAuthorsPlusRoles_TestCase {
 
 		// Setting a guest author as a non-byline role on a post should also include
 		// them in the get_coauthors() response for that post.
-		\CoAuthorsPlusRoles\set_contributor_on_post( $post, $guest_author_2 );
+		\CoAuthorsPlusRoles\set_contributor_on_post( $post, $guest_author_2_user_object, 'contributor' );
 		$all_credits_on_post = CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'any' ) );
 		$this->assertContains( $guest_author_2, wp_list_pluck( $all_credits_on_post, 'ID' ) );
 
@@ -118,20 +121,33 @@ class Test_Manage_ContributorRoles extends CoAuthorsPlusRoles_TestCase {
 			'display_name' => 'Guest Author through UI',
 			'user_login' => 'guest-author-through-ui'
 		) );
-		\CoAuthorsPlusRoles\update_coauthors_on_post( $post, array( "{$guest_author}|||author" ) );
+		$guest_author_nicename = $coauthors_plus->get_coauthor_by( 'id', $guest_author )->user_nicename;
+
+		\CoAuthorsPlusRoles\update_coauthors_on_post( $post, array( "{$guest_author_nicename}|||author" ) );
 		$updated_coauthors = \CoAuthorsPlusRoles\get_coauthors( (int) $post, array( 'author_role' => 'any' ) );
 		$this->assertCount( 1, $updated_coauthors );
 		$this->assertContains( $guest_author, wp_list_pluck( $updated_coauthors, 'ID' ) );
 
-		// Calling update_coauthors_on_post with an array should add all the new authors
-		\CoAuthorsPlusRoles\update_coauthors_on_post( $post,
-			array( "{$this->author1_post1}|||author", "{$guest_author}|||contributor" )
-		);
-		$updated_coauthors = \CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'any' ) );
-		$this->assertCount( 2, $updated_coauthors );
-		$contributors = \CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'contributor' ) );
-		$this->assertCount( 1, $contributors );
+		$user1 = get_userdata( $this->author1 );
 
+		\CoAuthorsPlusRoles\update_coauthors_on_post( $post,
+			array( "{$user1->user_login}|||author", "guest-author-through-ui|||contributor" )
+		);
+		// Calling update_coauthors_on_post with an array should add all the new authors
+		// Using: one WP_User, and one of Guest Author post type
+		\CoAuthorsPlusRoles\update_coauthors_on_post( $post,
+			array( "{$user1->user_login}|||author", "guest-author-through-ui|||contributor" )
+		);
+
+		// Both should show up in a query with author_role = any
+		$updated_coauthors = \CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'any' ) );
+		$this->assertContains( $user1->user_login, wp_list_pluck( $updated_coauthors, 'user_nicename' ) );
+		$this->assertContains( 'guest-author-through-ui', wp_list_pluck( $updated_coauthors, 'user_nicename' ) );
+
+		// Only the contributor should show up in this query where author_role = contributor
+		$contributors = \CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'contributor' ) );
+		$this->assertNotContains( $user1->user_login, wp_list_pluck( $contributors, 'user_nicename' ) );
+		$this->assertContains( 'guest-author-through-ui', wp_list_pluck( $contributors, 'user_nicename' ) );
 	}
 
 }

--- a/tests/test-manage-contributors.php
+++ b/tests/test-manage-contributors.php
@@ -82,6 +82,10 @@ class Test_Manage_ContributorRoles extends CoAuthorsPlusRoles_TestCase {
 		$guest_author_1_user_object = $coauthors_plus->get_coauthor_by( 'id', $guest_author_1 );
 		$guest_author_2_user_object = $coauthors_plus->get_coauthor_by( 'id', $guest_author_2 );
 
+		// search_coauthors() on a post with no search term specified should return all coauthors on the site
+		$all_contributors = CoAuthorsPlusRoles\search_coauthors( false, $post );
+		$this->assertContains( $guest_author_1, wp_list_pluck( $all_contributors, 'ID' ) );
+
 		// Setting a guest author as a contributor on a post should include
 		// them in the get_coauthors() response for that post.
 		\CoAuthorsPlusRoles\set_contributor_on_post( $post, $guest_author_1_user_object );
@@ -98,7 +102,8 @@ class Test_Manage_ContributorRoles extends CoAuthorsPlusRoles_TestCase {
 		$all_credits_on_post = CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'any' ) );
 		$this->assertContains( $guest_author_2, wp_list_pluck( $all_credits_on_post, 'ID' ) );
 
-		// After adding author to post, search_coauthors() on that post should no longer return them.
+		// After adding author to post in non-byline role, search_coauthors() on that post should no
+		// longer return them.
 		$all_contributors = CoAuthorsPlusRoles\search_coauthors( false, $post );
 		$this->assertNotContains( $guest_author_2, wp_list_pluck( $all_contributors, 'ID' ) );
 

--- a/tests/test-manage-contributors.php
+++ b/tests/test-manage-contributors.php
@@ -130,9 +130,6 @@ class Test_Manage_ContributorRoles extends CoAuthorsPlusRoles_TestCase {
 
 		$user1 = get_userdata( $this->author1 );
 
-		\CoAuthorsPlusRoles\update_coauthors_on_post( $post,
-			array( "{$user1->user_login}|||author", "guest-author-through-ui|||contributor" )
-		);
 		// Calling update_coauthors_on_post with an array should add all the new authors
 		// Using: one WP_User, and one of Guest Author post type
 		\CoAuthorsPlusRoles\update_coauthors_on_post( $post,
@@ -140,7 +137,7 @@ class Test_Manage_ContributorRoles extends CoAuthorsPlusRoles_TestCase {
 		);
 
 		// Both should show up in a query with author_role = any
-		$updated_coauthors = \CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'any' ) );
+		$updated_coauthors = \CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => false ) );
 		$this->assertContains( $user1->user_login, wp_list_pluck( $updated_coauthors, 'user_nicename' ) );
 		$this->assertContains( 'guest-author-through-ui', wp_list_pluck( $updated_coauthors, 'user_nicename' ) );
 


### PR DESCRIPTION
Addresses #9: because user ID's have the potential to overlap with post ID's (which are used as the ID for guest authors), this plugin will need to store the user_nicename instead.

Also, beefed up some of the tests in place and refactored out some of the copypasta from Co-Authors Plus.  