### PR TITLE
Fix all server side admin actions, improve test coverage 

### DIFF
--- a/co-authors-plus-roles.php
+++ b/co-authors-plus-roles.php
@@ -62,8 +62,8 @@ class CoAuthorsPlusRoles {
 
 		if ( $notices && is_array( $notices ) ) {
 			echo '
-				<div id="message" class="' . $notices['class'] . '">
-					<p>' . $notices['message'] . '</p>
+				<div id="message" class="' . esc_attr( $notices['class'] ) . '">
+					<p>' . esc_html( $notices['message'] ) . '</p>
 				</div>';
 			delete_option( 'co_authors_plus_roles__notices' );
 		}

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -120,7 +120,7 @@ function coauthors_meta_box( $post ) {
 			return $author;
 		}, $coauthors );
 
-	echo '<p>' . __( 'Click on an author to change them. Drag to change their order. Click on <b>Remove</b> to remove them.', 'co-authors-plus-roles' ) . '</p>';
+	echo '<p>' . esc_html__( 'Click on an author to change them. Drag to change their order. Click on <b>Remove</b> to remove them.', 'co-authors-plus-roles' ) . '</p>';
 
 	wp_nonce_field( 'coauthors_save', 'edit_coauthorsplus_roles_nonce' );
 
@@ -135,7 +135,7 @@ function coauthors_meta_box( $post ) {
 	echo '</ul>';
 
 	echo '<h4><a class="hide-if-no-js" href="#coauthor-add" id="coauthor-add-toggle">'
-		. __( '+ Add New Author', 'co-authors-plus-roles' ) . '</a></h4>';
+		. esc_html__( '+ Add New Author', 'co-authors-plus-roles' ) . '</a></h4>';
 
 }
 
@@ -166,31 +166,31 @@ function template_coauthor_sortable( $coauthor, $author_role = null ) {
 	// The format in which these values are posted.
 	$coauthor_input_value = "{$coauthor->user_nicename}|||{$coauthor->author_role}";
 	?>
-	<li id="menu-item-<?php echo $coauthor->user_nicename; ?>" class="menu-item coauthor-sortable">
+	<li id="menu-item-<?php echo esc_attr( $coauthor->user_nicename ); ?>" class="menu-item coauthor-sortable">
 		<dl class="menu-item-bar">
 			<dt class="menu-item-handle">
 				<span class="author-avatar">
 					<?php echo get_avatar( $coauthor->user_email, 48 ); ?>
 				</span>
 				<span class="author-info sortable-flex-section">
-					<span class="author-name"><?php echo $coauthor->display_name; ?></span>
-					<span class="author-email"><?php echo $coauthor->user_email; ?></span>
+					<span class="author-name"><?php echo esc_html( $coauthor->display_name ); ?></span>
+					<span class="author-email"><?php echo esc_html( $coauthor->user_email ); ?></span>
 				</span>
 				<?php $author_role = ( ! empty( $coauthor->author_role ) ) ?
-										$coauthor->author_role : 'BYLINE'; ?>
+										$coauthor->author_role : esc_html__( 'BYLINE', 'co-authors-plus-roles' ); ?>
 				<span class="author-role sortable-flex-section">
 					<a class="edit-coauthor"
-						data-author-name="<?php echo $coauthor->user_nicename; ?>"
-						data-role="<?php echo $author_role; ?>"
-						data-author-id="<?php echo $coauthor->user_nicename; ?>"
-						><?php echo $author_role; ?></a>
+						data-author-name="<?php echo esc_attr( $coauthor->user_nicename ); ?>"
+						data-role="<?php echo esc_attr( $author_role ); ?>"
+						data-author-id="<?php echo esc_attr( $coauthor->user_nicename ); ?>"
+						><?php echo esc_html( $author_role ); ?></a>
 				</span>
 				<span class="author-controls sortable-flex-section">
 					<span class="publishing-actions">
-						<a class="remove-coauthor submitdelete deletion"><?php _e( 'Remove' ); ?></a>
+						<a class="remove-coauthor submitdelete deletion"><?php esc_attr_e( 'Remove', 'co-authors-plus-roles' ); ?></a>
 					</span>
 				</span>
-				<input type="hidden" name="coauthors[]" value="<?php echo $coauthor_input_value; ?>" />
+				<input type="hidden" name="coauthors[]" value="<?php echo esc_attr( $coauthor_input_value ); ?>" />
 			</dt>
 		</dl>
 	</li>
@@ -208,8 +208,8 @@ function ajax_template_coauthor_sortable() {
 	check_ajax_referer( 'coauthor-select', '_ajax_coauthor_template_nonce' );
 	global $coauthors_plus;
 
-	$coauthor = $coauthors_plus->get_coauthor_by( 'user_nicename', $_REQUEST['authorId'] );
-	$role = get_author_role( $_REQUEST['authorRole'] );
+	$coauthor = $coauthors_plus->get_coauthor_by( 'user_nicename', sanitize_text_field( $_REQUEST['authorId'] ) );
+	$role = get_author_role( sanitize_text_field( $_REQUEST['authorRole'] ) );
 
 	if ( ! $coauthor || ! $role ) {
 		wp_die( 'Missing required information.' );
@@ -265,17 +265,17 @@ function coauthor_select_dialog() {
 			<div id="coauthor-select-modal-title">
 				<span id="coauthor-select-header"></span>
 				<button type="button" id="coauthor-select-close">
-					<span class="screen-reader-text"><?php _e( 'Close' ); ?></span>
+					<span class="screen-reader-text"><?php esc_html_e( 'Close', 'co-authors-plus-roles' ); ?></span>
 				</button>
 			</div>
 			<div id="coauthor-select">
 				<div id="coauthor-options">
-					<p class="howto"><?php _e( 'Choose the role for this contributor:', 'coauthors-plus-roles' ); ?></p>
+					<p class="howto"><?php esc_html_e( 'Choose the role for this contributor:', 'coauthors-plus-roles' ); ?></p>
 					<select id="coauthor-select-role" name="coauthor-select-role">
-						<option value=""><?php _e( 'Choose a role', 'coauthors-plus-roles' ); ?></option>
+						<option value=""><?php esc_html_e( 'Choose a role', 'coauthors-plus-roles' ); ?></option>
 					<?php $roles_available = apply_filters( 'coauthors_author_roles', get_author_roles(), $post_id );
 						foreach ( $roles_available as $role ) {
-							echo '<option value="' . $role->slug . '">' . $role->name . '</option>';
+							echo '<option value="' . esc_attr( $role->slug ) . '">' . esc_html( $role->name ) . '</option>';
 						}
 					?>
 					</select>
@@ -284,7 +284,7 @@ function coauthor_select_dialog() {
 				<div id="coauthor-search-panel">
 					<div class="coauthor-search-wrapper">
 						<label>
-							<p class="howto"><?php _e( 'Search by name or email address:', 'coauthors-plus-roles' ); ?></p>
+							<p class="howto"><?php esc_html_e( 'Search by name or email address:', 'coauthors-plus-roles' ); ?></p>
 							<input type="search" id="coauthor-search-field" class="coauthor-search-field" autocomplete="off" />
 							<span class="spinner"></span>
 						</label>
@@ -297,8 +297,8 @@ function coauthor_select_dialog() {
 					</div>
 					<div id="most-recent-results" class="query-results" tabindex="0">
 						<div class="query-notice" id="query-notice-message">
-							<em class="query-notice-default"><?php _e( 'No search term specified. Showing recent items.' ); ?></em>
-							<em class="query-notice-hint screen-reader-text"><?php _e( 'Search or use up and down arrow keys to select an item.' ); ?></em>
+							<em class="query-notice-default"><?php esc_html_e( 'No search term specified. Showing recent items.', 'co-authors-plus-roles' ); ?></em>
+							<em class="query-notice-hint screen-reader-text"><?php esc_html_e( 'Search or use up and down arrow keys to select an item.', 'co-authors-plus-roles' ); ?></em>
 						</div>
 						<ul></ul>
 						<div class="river-waiting">
@@ -309,10 +309,10 @@ function coauthor_select_dialog() {
 			</div>
 			<div class="submitbox">
 				<div id="coauthor-select-cancel">
-					<a class="submitdelete deletion" href="#"><?php _e( 'Cancel' ); ?></a>
+					<a class="submitdelete deletion" href="#"><?php esc_html_e( 'Cancel', 'co-authors-plus-roles' ); ?></a>
 				</div>
 				<div id="coauthor-select-update">
-					<input type="submit" value="<?php esc_attr_e( 'Add coauthor to post' ); ?>" class="button button-primary" id="coauthor-select-submit" name="coauthor-select-submit">
+					<input type="submit" value="<?php esc_attr_e( 'Add coauthor to post', 'co-authors-plus-roles' ); ?>" class="button button-primary" id="coauthor-select-submit" name="coauthor-select-submit">
 				</div>
 			</div>
 		</form>
@@ -448,9 +448,9 @@ function update_coauthors_on_post( $post_id, $new_coauthors ) {
 					global $coauthors_plus;
 
 					list( $author_name, $role ) = explode( '|||', $coauthor_string );
-					$new_coauthor = $coauthors_plus->get_coauthor_by( 'user_nicename', $author_name );
+					$new_coauthor = $coauthors_plus->get_coauthor_by( 'user_nicename', sanitize_text_field( $author_name ) );
 					if ( $new_coauthor ) {
-						$new_coauthor->author_role = $role;
+						$new_coauthor->author_role = sanitize_text_field( $role );
 						return $new_coauthor;
 					}
 				}, $new_coauthors
@@ -475,8 +475,8 @@ function update_coauthors_on_post( $post_id, $new_coauthors ) {
 
 		if ( $difference ) {
 			remove_all_coauthor_meta( $post_id );
-			foreach ( $new_coauthors as $coauthor ) {
-				set_author_on_post( $post_id, $coauthor, $coauthor->author_role );
+			foreach ( $new_coauthors as $new_coauthor ) {
+				set_author_on_post( $post_id, $new_coauthor, $new_coauthor->author_role );
 			}
 		}
 
@@ -494,6 +494,7 @@ function update_coauthors_on_post( $post_id, $new_coauthors ) {
 		$coauthors_plus->add_coauthors( $post_id, $byline_coauthors_slugs, false );
 	}
 }
+
 
 /**
  * Update the co-authors on a post on saving.
@@ -518,7 +519,7 @@ function action_update_coauthors_on_post( $post_id, $post ) {
 		// if current_user_can_set_authors and nonce valid
 		check_admin_referer( 'coauthors_save', 'edit_coauthorsplus_roles_nonce' );
 
-		$coauthors = (array) $_POST['coauthors'];
+		$coauthors = array_map( 'sanitize_text_field', (array) $_POST['coauthors'] );
 
 		update_coauthors_on_post( $post_id, $coauthors );
 

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -120,7 +120,11 @@ function coauthors_meta_box( $post ) {
 			return $author;
 		}, $coauthors );
 
-	echo '<p>' . __( 'Click on an author to change them. Drag to change their order. Click on <b>Remove</b> to remove them.', 'co-authors-plus-roles' ) . '</p>';
+	echo '<p>' .
+		sprintf(
+			esc_html__( 'Click on an author to change them. Drag to change their order. Click on %s to remove them.', 'co-authors-plus-roles' ),
+			'<b>' . esc_html__( 'Remove', 'co-authors-plus-roles' ) . '</b>'
+		) . '</p>';
 
 	wp_nonce_field( 'coauthors_save', 'edit_coauthorsplus_roles_nonce' );
 

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -159,6 +159,10 @@ function template_coauthor_sortable( $coauthor, $author_role = null ) {
 		$coauthor->type = 'WP USER';
 	}
 
+	if ( ! isset( $coauthor->author_role ) ) {
+		$coauthor->author_role = '';
+	}
+
 	// The format in which these values are posted.
 	$coauthor_input_value = "{$coauthor->user_nicename}|||{$coauthor->author_role}";
 	?>

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -120,7 +120,7 @@ function coauthors_meta_box( $post ) {
 			return $author;
 		}, $coauthors );
 
-	echo '<p>' . esc_html__( 'Click on an author to change them. Drag to change their order. Click on <b>Remove</b> to remove them.', 'co-authors-plus-roles' ) . '</p>';
+	echo '<p>' . __( 'Click on an author to change them. Drag to change their order. Click on <b>Remove</b> to remove them.', 'co-authors-plus-roles' ) . '</p>';
 
 	wp_nonce_field( 'coauthors_save', 'edit_coauthorsplus_roles_nonce' );
 

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -180,7 +180,7 @@ function template_coauthor_sortable( $coauthor, $author_role = null ) {
 										$coauthor->author_role : 'BYLINE'; ?>
 				<span class="author-role sortable-flex-section">
 					<a class="edit-coauthor"
-						data-author-name="<?php echo $coauthor->display_name; ?>"
+						data-author-name="<?php echo $coauthor->user_nicename; ?>"
 						data-role="<?php echo $author_role; ?>"
 						data-author-id="<?php echo $coauthor->user_nicename; ?>"
 						><?php echo $author_role; ?></a>
@@ -463,7 +463,7 @@ function update_coauthors_on_post( $post_id, $new_coauthors ) {
 			if ( ! isset( $new_coauthors[$i] ) || !isset( $existing_coauthors[ $i ] ) ) {
 				$difference = true; break;
 			}
-			if ( $new_coauthors[ $i ]->display_name !== $existing_coauthors[ $i ]->display_name ) {
+			if ( $new_coauthors[ $i ]->user_nicename !== $existing_coauthors[ $i ]->user_nicename ) {
 				$difference = true; break;
 			}
 			if ( $new_coauthors[ $i ]->author_role !== $existing_coauthors[ $i ]->author_role ) {

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -180,13 +180,19 @@ function template_coauthor_sortable( $coauthor, $author_role = null ) {
 					<span class="author-name"><?php echo esc_html( $coauthor->display_name ); ?></span>
 					<span class="author-email"><?php echo esc_html( $coauthor->user_email ); ?></span>
 				</span>
-				<?php $author_role = ( ! empty( $coauthor->author_role ) ) ?
-										$coauthor->author_role : esc_html__( 'BYLINE', 'co-authors-plus-roles' ); ?>
+				<?php
+					/*
+					 * The special case where `author_role` is empty should be handled separately.
+					 * An empty role means that its treated as a "byline". We give it a name here for display purposes,
+					 * but this name is never saved.
+					 */
+					$author_role = ( ! empty( $coauthor->author_role ) ) ?
+								$coauthor->author_role : esc_html__( 'byline', 'co-authors-plus-roles' ); ?>
 				<span class="author-role sortable-flex-section">
 					<a class="edit-coauthor"
 						data-author-name="<?php echo esc_attr( $coauthor->user_nicename ); ?>"
 						data-role="<?php echo esc_attr( $author_role ); ?>"
-						data-author-id="<?php echo esc_attr( $coauthor->user_nicename ); ?>"
+						data-author-nicename="<?php echo esc_attr( $coauthor->user_nicename ); ?>"
 						><?php echo esc_html( $author_role ); ?></a>
 				</span>
 				<span class="author-controls sortable-flex-section">
@@ -212,7 +218,7 @@ function ajax_template_coauthor_sortable() {
 	check_ajax_referer( 'coauthor-select', '_ajax_coauthor_template_nonce' );
 	global $coauthors_plus;
 
-	$coauthor = $coauthors_plus->get_coauthor_by( 'user_nicename', sanitize_text_field( $_REQUEST['authorId'] ) );
+	$coauthor = $coauthors_plus->get_coauthor_by( 'user_nicename', sanitize_text_field( $_REQUEST['authorNicename'] ) );
 	$role = get_author_role( sanitize_text_field( $_REQUEST['authorRole'] ) );
 
 	if ( ! $coauthor || ! $role ) {
@@ -283,7 +289,7 @@ function coauthor_select_dialog() {
 						}
 					?>
 					</select>
-					<input type="hidden" id="coauthor-author-id" value="" />
+					<input type="hidden" id="coauthor-author-nicename" value="" />
 				</div>
 				<div id="coauthor-search-panel">
 					<div class="coauthor-search-wrapper">

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -176,7 +176,7 @@ function template_coauthor_sortable( $coauthor, $author_role = null ) {
 					<span class="author-name"><?php echo $coauthor->display_name; ?></span>
 					<span class="author-email"><?php echo $coauthor->user_email; ?></span>
 				</span>
-				<?php $author_role = ( isset( $coauthor->author_role ) ) ?
+				<?php $author_role = ( ! empty( $coauthor->author_role ) ) ?
 										$coauthor->author_role : 'BYLINE'; ?>
 				<span class="author-role sortable-flex-section">
 					<a class="edit-coauthor"
@@ -240,7 +240,9 @@ function enqueue_scripts() {
 			'save' => __( 'Add Author', 'co-authors-plus-roles' ),
 			'noMatchesFound' => __( 'No results found.', 'co-authors-plus-roles' ),
 			'addNewAuthorHeader' => __( 'Add new author to post', 'coauthors-plus-roles' ),
-			'editExistingAuthorHeader' => __( 'Edit author on post', 'coauthors-plus-roles' )
+			'editExistingAuthorHeader' => __( 'Edit author on post', 'coauthors-plus-roles' ),
+			'addNewAuthorButton' => __( 'Add author to post', 'coauthors-plus-roles' ),
+			'editExistingAuthorButton' => __( 'Save changes to author', 'coauthors-plus-roles' )
 		)
 	);
 }

--- a/includes/admin-edit-ui.php
+++ b/includes/admin-edit-ui.php
@@ -239,10 +239,10 @@ function enqueue_scripts() {
 			'update' => __( 'Update', 'co-authors-plus-roles' ),
 			'save' => __( 'Add Author', 'co-authors-plus-roles' ),
 			'noMatchesFound' => __( 'No results found.', 'co-authors-plus-roles' ),
-			'addNewAuthorHeader' => __( 'Add new author to post', 'coauthors-plus-roles' ),
-			'editExistingAuthorHeader' => __( 'Edit author on post', 'coauthors-plus-roles' ),
-			'addNewAuthorButton' => __( 'Add author to post', 'coauthors-plus-roles' ),
-			'editExistingAuthorButton' => __( 'Save changes to author', 'coauthors-plus-roles' )
+			'addNewAuthorHeader' => __( 'Add new author to post', 'co-authors-plus-roles' ),
+			'editExistingAuthorHeader' => __( 'Edit author on post', 'co-authors-plus-roles' ),
+			'addNewAuthorButton' => __( 'Add author to post', 'co-authors-plus-roles' ),
+			'editExistingAuthorButton' => __( 'Save changes to author', 'co-authors-plus-roles' )
 		)
 	);
 }
@@ -270,9 +270,9 @@ function coauthor_select_dialog() {
 			</div>
 			<div id="coauthor-select">
 				<div id="coauthor-options">
-					<p class="howto"><?php esc_html_e( 'Choose the role for this contributor:', 'coauthors-plus-roles' ); ?></p>
+					<p class="howto"><?php esc_html_e( 'Choose the role for this contributor:', 'co-authors-plus-roles' ); ?></p>
 					<select id="coauthor-select-role" name="coauthor-select-role">
-						<option value=""><?php esc_html_e( 'Choose a role', 'coauthors-plus-roles' ); ?></option>
+						<option value=""><?php esc_html_e( 'Choose a role', 'co-authors-plus-roles' ); ?></option>
 					<?php $roles_available = apply_filters( 'coauthors_author_roles', get_author_roles(), $post_id );
 						foreach ( $roles_available as $role ) {
 							echo '<option value="' . esc_attr( $role->slug ) . '">' . esc_html( $role->name ) . '</option>';
@@ -284,7 +284,7 @@ function coauthor_select_dialog() {
 				<div id="coauthor-search-panel">
 					<div class="coauthor-search-wrapper">
 						<label>
-							<p class="howto"><?php esc_html_e( 'Search by name or email address:', 'coauthors-plus-roles' ); ?></p>
+							<p class="howto"><?php esc_html_e( 'Search by name or email address:', 'co-authors-plus-roles' ); ?></p>
 							<input type="search" id="coauthor-search-field" class="coauthor-search-field" autocomplete="off" />
 							<span class="spinner"></span>
 						</label>

--- a/includes/author-roles-posts-relationships.php
+++ b/includes/author-roles-posts-relationships.php
@@ -19,7 +19,7 @@ namespace CoAuthorsPlusRoles;
  * @return bool True on success, false on failure (if any of the inputs are not acceptable).
  */
 function set_author_on_post( $post_id, $author, $author_role = false ) {
-	global $coauthors_plus, $wpdb;
+	global $coauthors_plus;
 
 	if ( is_object( $post_id ) && isset( $post_id->ID ) ) {
 		$post_id = $post_id->ID;
@@ -46,12 +46,11 @@ function set_author_on_post( $post_id, $author, $author_role = false ) {
 		return false;
 	}
 
-	$drop_existing_role = $wpdb->query(
-		$wpdb->prepare(
-			"DELETE FROM {$wpdb->postmeta} WHERE post_id=%d AND meta_key LIKE 'cap-%%' AND meta_value=%s",
-			array( $post_id, $author->user_nicename )
-		)
-	);
+	foreach ( get_post_meta( $post_id ) as $key => $values ) {
+		if ( strpos( $key, 'cap-' ) === 0 && in_array( $author->user_nicename, $values ) ) {
+			delete_post_meta( $post_id, $key, $author->user_nicename );
+		}
+	}
 
 	if ( ! is_object( $author_role ) ) {
 		$author_role = get_author_role( $author_role );
@@ -95,7 +94,7 @@ function remove_all_coauthor_meta( $post_id ) {
  * @return bool True on success, false on failure (if any of the inputs are not acceptable).
  */
 function remove_author_from_post( $post_id, $author ) {
-	global $coauthors_plus, $wpdb;
+	global $coauthors_plus;
 
 	if ( is_object( $post_id ) && isset( $post_id->ID ) ) {
 		$post_id = $post_id->ID;
@@ -117,11 +116,10 @@ function remove_author_from_post( $post_id, $author ) {
 	wp_set_object_terms( $post_id, $new_authors, $coauthors_plus->coauthor_taxonomy, true );
 
 	// Delete meta value setting contributor on post
-	$drop_existing_role = $wpdb->query(
-		$wpdb->prepare(
-			"DELETE FROM {$wpdb->postmeta} WHERE post_id=%d AND meta_key LIKE 'cap-%%' AND meta_value=%s",
-			array( $post_id, $author->user_nicename )
-		)
-	);
+	foreach ( get_post_meta( $post_id ) as $key => $values ) {
+		if ( strpos( $key, 'cap-' ) === 0 && in_array( $author->display_name, $values ) ) {
+			delete_post_meta( $post_id, $key, $author->display_name );
+		}
+	}
 }
 

--- a/includes/author-roles-posts-relationships.php
+++ b/includes/author-roles-posts-relationships.php
@@ -56,14 +56,17 @@ function set_author_on_post( $post_id, $author, $author_role = false ) {
 	}
 
 	if ( ! is_object( $author_role ) ) {
-		$author_role = get_author_role( $author_role );
+		$author_role = get_author_role( sanitize_text_field( $author_role ) );
 	}
 
 	if ( ! $author_role ) {
 		return false;
 	}
 
-	add_post_meta( $post_id, 'cap-' . $author_role->slug, $author->user_nicename );
+	add_post_meta( $post_id,
+		sanitize_key( 'cap-' . $author_role->slug ),
+		sanitize_user( $author->user_nicename )
+	);
 }
 
 
@@ -108,9 +111,9 @@ function remove_author_from_post( $post_id, $author ) {
 	$post_id = intval( $post_id );
 
 	if ( is_string( $author ) ) {
-		$author = $coauthors_plus->get_coauthor_by( 'user_nicename', $author );
+		$author = $coauthors_plus->get_coauthor_by( 'user_nicename', sanitize_text_field( $author ) );
 	} else if ( is_int( $author ) ) {
-		$author = $coauthors_plus->get_coauthor_by( 'id', $author );
+		$author = $coauthors_plus->get_coauthor_by( 'id', sanitize_text_field( $author ) );
 	}
 
 	if ( !is_object( $author ) ) {

--- a/includes/author-roles-posts-relationships.php
+++ b/includes/author-roles-posts-relationships.php
@@ -75,15 +75,17 @@ function set_author_on_post( $post_id, $author, $author_role = false ) {
  * @param int $post_id Post to remove coauthor postmeta from
  */
 function remove_all_coauthor_meta( $post_id ) {
-	$post_meta = get_post_meta( $post_id );
-	$user_nicenames = wp_list_pluck( get_top_authors(), 'user_nicename' );
 
-	foreach ( $post_meta as $key => $values ) {
-		if ( strpos( $key, 'cap-' === 0 ) ) {
-			foreach ( $values as $value ) {
-				if ( in_array( $value, $user_nicenames ) )
-					delete_post_meta( $post_id, $key, $value );
-			}
+	// Get the author_role terms as they would be stored in post meta: look up all the author roles
+	// registered, and add the "cap-" prefix to generate the key used here.
+	$roles_meta_keys = array_map(
+		function( $term ) { return 'cap-' . $term->slug; },
+		get_author_roles()
+	);
+
+	foreach ( get_post_meta( $post_id ) as $key => $values ) {
+		if ( in_array( $key, $roles_meta_keys ) ) {
+			delete_post_meta( $post_id, $key );
 		}
 	}
 }

--- a/includes/author-roles-posts-relationships.php
+++ b/includes/author-roles-posts-relationships.php
@@ -27,10 +27,8 @@ function set_author_on_post( $post_id, $author, $author_role = false ) {
 
 	$post_id = intval( $post_id );
 
-	if ( is_string( $author ) && intval( $author ) != $author ) {
+	if ( is_string( $author ) ) {
 		$author = $coauthors_plus->get_coauthor_by( 'user_nicename', $author );
-	} else if ( is_int( $author ) ) {
-		$author = $coauthors_plus->get_coauthor_by( 'id', $author );
 	}
 
 	if ( ! isset( $author->user_nicename ) ) {
@@ -63,7 +61,29 @@ function set_author_on_post( $post_id, $author, $author_role = false ) {
 		return false;
 	}
 
-	update_post_meta( $post_id, 'cap-' . $author_role->slug, $author->user_nicename );
+	add_post_meta( $post_id, 'cap-' . $author_role->slug, $author->user_nicename );
+}
+
+
+/**
+ * Clear all coauthor data on a post.
+ *
+ * Used when updating coauthors, as otherwise there's no way of ordering them.
+ *
+ * @param int $post_id Post to remove coauthor postmeta from
+ */
+function remove_all_coauthor_meta( $post_id ) {
+	$post_meta = get_post_meta( $post_id );
+	$user_nicenames = wp_list_pluck( get_top_authors(), 'user_nicename' );
+
+	foreach ( $post_meta as $key => $values ) {
+		if ( strpos( $key, 'cap-' === 0 ) ) {
+			foreach ( $values as $value ) {
+				if ( in_array( $value, $user_nicenames ) )
+					delete_post_meta( $post_id, $key, $value );
+			}
+		}
+	}
 }
 
 

--- a/includes/author-roles-posts-relationships.php
+++ b/includes/author-roles-posts-relationships.php
@@ -56,17 +56,14 @@ function set_author_on_post( $post_id, $author, $author_role = false ) {
 	}
 
 	if ( ! is_object( $author_role ) ) {
-		$author_role = get_author_role( sanitize_text_field( $author_role ) );
+		$author_role = get_author_role( $author_role );
 	}
 
 	if ( ! $author_role ) {
 		return false;
 	}
 
-	add_post_meta( $post_id,
-		sanitize_key( 'cap-' . $author_role->slug ),
-		sanitize_user( $author->user_nicename )
-	);
+	add_post_meta( $post_id, 'cap-' . $author_role->slug, $author->user_nicename );
 }
 
 

--- a/includes/js/coauthors.js
+++ b/includes/js/coauthors.js
@@ -18,13 +18,13 @@ var coauthorsSelector, coauthorsSortable;
 		openSelectorToEdit: function(evt) {
 			var link = $(evt.currentTarget),
 				thisLi = link.closest('li.coauthor-sortable'),
-				thisAuthor = link.data( 'author-id' );
+				thisAuthor = link.data( 'author-nicename' );
 
 			coauthorsSelector.open( thisLi );
 			currentlyEditing = thisLi;
 
 			inputs.role.val( link.data('role') );
-			inputs.authorId.val( link.data('author-id') );
+			inputs.authorNicename.val( link.data('author-nicename') );
 			inputs.search.val( link.data('author-name') );
 
 			inputs.search.trigger('keyup');
@@ -62,7 +62,7 @@ var coauthorsSelector, coauthorsSortable;
 
 			// Inputs
 			inputs.role = $( '#coauthor-select-role' );
-			inputs.authorId = $( '#coauthor-author-id' );
+			inputs.authorNicename = $( '#coauthor-author-nicename' );
 			inputs.postId = $( '#coauthor-post-id' );
 			inputs.nonce = $( '#_coauthor_select_nonce' );
 
@@ -142,7 +142,7 @@ var coauthorsSelector, coauthorsSortable;
 
 			// Reset each of the inputs
 			inputs.role.val();
-			inputs.authorId.val();
+			inputs.authorNicename.val();
 			inputs.search.val();
 
 			// Refresh rivers (clear links, check visibility)
@@ -181,21 +181,21 @@ var coauthorsSelector, coauthorsSortable;
 		getAttrs: function() {
 			return {
 				role: inputs.role.val(),
-				authorId: inputs.authorId.val()
+				authorNicename: inputs.authorNicename.val()
 			};
 		},
 
 		update: function() {
 			// validate that an author ID and role are selected
 			// XXX this is p awful. work out a better UX for this form
-			if ( ! inputs.authorId.val() || ! inputs.role.val() ) {
+			if ( ! inputs.authorNicename.val() || ! inputs.role.val() ) {
 				alert( "something's not filled out!" );
 				return false; // TODO: helpful error message
 			}
 
 			var query = {
 					action: 'coauthor-sortable-template',
-					authorId: inputs.authorId.val(),
+					authorNicename: inputs.authorNicename.val(),
 					authorRole: inputs.role.val(),
 					'_ajax_coauthor_template_nonce': inputs.nonce.val()
 				};
@@ -214,7 +214,7 @@ var coauthorsSelector, coauthorsSortable;
 		},
 
 		updateFields: function( e, li ) {
-			inputs.authorId.val( li.children( '.item-id' ).val() );
+			inputs.authorNicename.val( li.children( '.item-nicename' ).val() );
 		},
 
 		searchAuthors: function() {
@@ -449,7 +449,7 @@ var coauthorsSelector, coauthorsSortable;
 					classes = alt ? 'alternate' : '';
 					classes += this.post_title ? '' : ' no-title';
 					list += classes ? '<li class="' + classes + '">' : '<li>';
-					list += '<input type="hidden" class="item-id" value="' + this.user_nicename + '" />';
+					list += '<input type="hidden" class="item-nicename" value="' + this.user_nicename + '" />';
 					list += '<span class="item-title">';
 					list += this.display_name ? this.display_name : coauthorsL10n.noTitle;
 					list += '</span><span class="item-info">' + this.type.replace('-',' ') + '</span></li>';

--- a/includes/js/coauthors.js
+++ b/includes/js/coauthors.js
@@ -113,8 +113,8 @@ var coauthorsSelector, coauthorsSortable;
 			coauthorsSelector.range = null;
 
 			inputs.header.text( function() {
-				return currentlyEditing ? 
-					coauthorsL10n.editExistingAuthorHeader : 
+				return currentlyEditing ?
+					coauthorsL10n.editExistingAuthorHeader :
 					coauthorsL10n.addNewAuthorHeader;
 			});
 
@@ -432,7 +432,7 @@ var coauthorsSelector, coauthorsSortable;
 					classes = alt ? 'alternate' : '';
 					classes += this.post_title ? '' : ' no-title';
 					list += classes ? '<li class="' + classes + '">' : '<li>';
-					list += '<input type="hidden" class="item-id" value="' + this.ID + '" />';
+					list += '<input type="hidden" class="item-id" value="' + this.display_name + '" />';
 					list += '<span class="item-title">';
 					list += this.display_name ? this.display_name : coauthorsL10n.noTitle;
 					list += '</span><span class="item-info">' + this.type.replace('-',' ') + '</span></li>';

--- a/includes/js/coauthors.js
+++ b/includes/js/coauthors.js
@@ -20,9 +20,8 @@ var coauthorsSelector, coauthorsSortable;
 				thisLi = link.closest('li.coauthor-sortable'),
 				thisAuthor = link.data( 'author-id' );
 
+			coauthorsSelector.open( thisLi );
 			currentlyEditing = thisLi;
-
-			coauthorsSelector.open();
 
 			inputs.role.val( link.data('role') );
 			inputs.authorId.val( link.data('author-id') );
@@ -31,11 +30,17 @@ var coauthorsSelector, coauthorsSortable;
 			inputs.search.trigger('keyup');
 		},
 
+		openSelectorForNewElement: function(evt) {
+			currentlyEditing = false;
+			coauthorsSelector.open( false );
+			coauthorsSelector.refresh();
+		},
+
 		init: function() {
 			this.list.sortable();
 			this.list.on( 'click', 'a.remove-coauthor', this.removeSortableLi );
 			this.list.on( 'click', 'a.edit-coauthor', this.openSelectorToEdit );
-			this.toggle.on( 'click', coauthorsSelector.open );
+			this.toggle.on( 'click', this.openSelectorForNewElement );
 		}
 	};
 
@@ -84,6 +89,7 @@ var coauthorsSelector, coauthorsSortable;
 			inputs.close.add( inputs.backdrop ).add( '#coauthor-select-cancel a' ).click( function( event ) {
 				event.preventDefault();
 				coauthorsSelector.close();
+				currentlyEditing = false;
 			});
 
 			rivers.elements.on( 'coauthors-river-select', coauthorsSelector.updateFields );
@@ -107,7 +113,7 @@ var coauthorsSelector, coauthorsSortable;
 			});
 		},
 
-		open: function() {
+		open: function( currentlyEditing ) {
 			$( document.body ).addClass( 'modal-open' );
 
 			coauthorsSelector.range = null;
@@ -116,6 +122,12 @@ var coauthorsSelector, coauthorsSortable;
 				return currentlyEditing ?
 					coauthorsL10n.editExistingAuthorHeader :
 					coauthorsL10n.addNewAuthorHeader;
+			});
+
+			inputs.submit.attr( 'value',  function() {
+				return currentlyEditing ?
+					coauthorsL10n.editExistingAuthorButton :
+					coauthorsL10n.addNewAuthorButton;
 			});
 
 			inputs.wrap.show();
@@ -156,9 +168,13 @@ var coauthorsSelector, coauthorsSortable;
 		close: function() {
 			$( document.body ).removeClass( 'modal-open' );
 
-			currentlyEditing = false;
 			inputs.backdrop.hide();
 			inputs.wrap.hide();
+
+			window.setTimeout(
+				function() { coauthorsSelector.refresh(); }, 5000
+			);
+
 			$( document ).trigger( 'coauthor-select-close', inputs.wrap );
 		},
 
@@ -187,6 +203,7 @@ var coauthorsSelector, coauthorsSortable;
 			$.post( ajaxurl, query, function( r ) {
 				if ( currentlyEditing ) {
 					currentlyEditing.html( r )
+					currentlyEditing = false;
 				} else {
 					coauthorsSortable.list.append( r );
 				}
@@ -432,7 +449,7 @@ var coauthorsSelector, coauthorsSortable;
 					classes = alt ? 'alternate' : '';
 					classes += this.post_title ? '' : ' no-title';
 					list += classes ? '<li class="' + classes + '">' : '<li>';
-					list += '<input type="hidden" class="item-id" value="' + this.display_name + '" />';
+					list += '<input type="hidden" class="item-id" value="' + this.user_nicename + '" />';
 					list += '<span class="item-title">';
 					list += this.display_name ? this.display_name : coauthorsL10n.noTitle;
 					list += '</span><span class="item-info">' + this.type.replace('-',' ') + '</span></li>';

--- a/includes/query.php
+++ b/includes/query.php
@@ -94,7 +94,9 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 			if ( in_array( $key, $roles_meta_keys ) ) {
 				foreach ( $values as $author_name ) {
 					$author = $coauthors_plus->get_coauthor_by( 'user_nicename', $author_name );
-					$author->author_role = get_author_role( substr( $key, 4 ) );
+					if ( $role = get_author_role( substr( $key, 4 ) ) ) {
+						$author->author_role = $role->slug;
+					}
 					$coauthors[] = $author;
 				}
 			}

--- a/includes/query.php
+++ b/includes/query.php
@@ -121,7 +121,7 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 					}
 
 					$post_author = $coauthors_plus->get_coauthor_by( 'user_nicename', $coauthor_slug );
-					$post_author->author_role = '';
+					$post_author->author_role = __( 'BYLINE', 'co-authors-plus-roles' );
 
 					// In case the user has been deleted while plugin was deactivated
 					if ( ! empty( $post_author ) ) {

--- a/includes/query.php
+++ b/includes/query.php
@@ -75,9 +75,9 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 		if ( $args['author_role'] === 'any' || ! $args['author_role'] ) {
 			$author_roles = wp_list_pluck( get_author_roles(), 'slug' );
 		} else if ( is_string( $args['author_role'] ) ) {
-			$author_roles = array( sanitize_text_field( $args['author_role'] ) );
+			$author_roles = array( $args['author_role'] );
 		} else {
-			$author_roles = array_map( 'sanitize_text_field', $args['author_role'] );
+			$author_roles = $args['author_role'];
 		}
 
 		// Get the terms as stored in post meta: look up all the author roles passed in by function
@@ -121,7 +121,13 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 					}
 
 					$post_author = $coauthors_plus->get_coauthor_by( 'user_nicename', $coauthor_slug );
-					$post_author->author_role = __( 'BYLINE', 'co-authors-plus-roles' );
+
+					/*
+					 * The special case where `author_role` is empty should be handled separately.
+					 * An empty role means that its treated as a "byline". We give it a name here for display purposes,
+					 * but this name is never saved.
+					 */
+					$post_author->author_role = esc_html__( 'byline', 'co-authors-plus-roles' );
 
 					// In case the user has been deleted while plugin was deactivated
 					if ( ! empty( $post_author ) ) {

--- a/includes/query.php
+++ b/includes/query.php
@@ -108,6 +108,8 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 			// Now, get the author terms, in case of bylines or coauthors who were entered with CAP.
 			$coauthor_terms = get_the_terms( $post_id, $coauthors_plus->coauthor_taxonomy );
 
+			$byline_coauthors = array();
+
 			if ( is_array( $coauthor_terms ) && ! empty( $coauthor_terms ) ) {
 				foreach ( $coauthor_terms as $coauthor ) {
 					$coauthor_slug = preg_replace( '#^cap\-#', '', $coauthor->slug );
@@ -123,10 +125,12 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 
 					// In case the user has been deleted while plugin was deactivated
 					if ( ! empty( $post_author ) ) {
-						$coauthors[] = $post_author;
+						$byline_coauthors[] = $post_author;
 					}
 				}
 			}
+
+			$coauthors = array_merge( $byline_coauthors, $coauthors );
 		}
 	}
 	return $coauthors;

--- a/includes/query.php
+++ b/includes/query.php
@@ -75,9 +75,9 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 		if ( $args['author_role'] === 'any' || ! $args['author_role'] ) {
 			$author_roles = wp_list_pluck( get_author_roles(), 'slug' );
 		} else if ( is_string( $args['author_role'] ) ) {
-			$author_roles = array( $args['author_role'] );
+			$author_roles = array( sanitize_text_field( $args['author_role'] ) );
 		} else {
-			$author_roles = $args['author_role'];
+			$author_roles = array_map( 'sanitize_text_field', $args['author_role'] );
 		}
 
 		// Get the terms as stored in post meta: look up all the author roles passed in by function
@@ -121,7 +121,7 @@ function get_coauthors( $post_id = 0, $args = array() ) {
 					}
 
 					$post_author = $coauthors_plus->get_coauthor_by( 'user_nicename', $coauthor_slug );
-					$post_author->author_role = 'byline';
+					$post_author->author_role = '';
 
 					// In case the user has been deleted while plugin was deactivated
 					if ( ! empty( $post_author ) ) {

--- a/tests/test-manage-contributors.php
+++ b/tests/test-manage-contributors.php
@@ -142,7 +142,7 @@ class Test_Manage_Author_Roles extends CoAuthorsPlusRoles_TestCase {
 		);
 
 		// Both should show up in a query with author_role = any
-		$updated_coauthors = \CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => false ) );
+		$updated_coauthors = \CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'any' ) );
 		$this->assertContains( $user1->user_login, wp_list_pluck( $updated_coauthors, 'user_nicename' ) );
 		$this->assertContains( 'guest-author-through-ui', wp_list_pluck( $updated_coauthors, 'user_nicename' ) );
 
@@ -150,6 +150,19 @@ class Test_Manage_Author_Roles extends CoAuthorsPlusRoles_TestCase {
 		$contributors = \CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'contributor' ) );
 		$this->assertNotContains( $user1->user_login, wp_list_pluck( $contributors, 'user_nicename' ) );
 		$this->assertContains( 'guest-author-through-ui', wp_list_pluck( $contributors, 'user_nicename' ) );
+
+		// Updating coauthors in a different order; the same tests should pass, but the new order should be preserved.
+		\CoAuthorsPlusRoles\update_coauthors_on_post( $post,
+			array( "guest-author-through-ui|||contributor", "{$user1->user_login}|||author" )
+		);
+
+		// Both should show up in a query with author_role = any, and the first one posted should be first
+		$updated_coauthors = \CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'any' ) );
+
+		$this->assertContains( $user1->user_login, wp_list_pluck( $updated_coauthors, 'user_nicename' ) );
+		$this->assertContains( 'guest-author-through-ui', wp_list_pluck( $updated_coauthors, 'user_nicename' ) );
+		$this->assertEquals( 'guest-author-through-ui', $updated_coauthors[0]->user_nicename );
+
 	}
 
 }

--- a/tests/test-manage-contributors.php
+++ b/tests/test-manage-contributors.php
@@ -169,6 +169,10 @@ class Test_Manage_Author_Roles extends CoAuthorsPlusRoles_TestCase {
 		$updated_coauthors = \CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'author' ) );
 		$this->assertcount( 2, $updated_coauthors );
 
+		// Removing an individual coauthor using `remove_coauthor_from_post()`
+		\CoAuthorsPlusRoles\remove_author_from_post( $post, 'guest-author-through-ui' );
+		$updated_coauthors = \CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'any' ) );
+		$this->assertcount( 1, $updated_coauthors );
 	}
 
 }

--- a/tests/test-manage-contributors.php
+++ b/tests/test-manage-contributors.php
@@ -163,6 +163,12 @@ class Test_Manage_Author_Roles extends CoAuthorsPlusRoles_TestCase {
 		$this->assertContains( 'guest-author-through-ui', wp_list_pluck( $updated_coauthors, 'user_nicename' ) );
 		$this->assertEquals( 'guest-author-through-ui', $updated_coauthors[0]->user_nicename );
 
+		// Updating an individual coauthor; should change role (sorting is presently undefined...)
+		\CoAuthorsPlusRoles\set_author_on_post( $post, 'guest-author-through-ui', 'author' );
+
+		$updated_coauthors = \CoAuthorsPlusRoles\get_coauthors( $post, array( 'author_role' => 'author' ) );
+		$this->assertcount( 2, $updated_coauthors );
+
 	}
 
 }


### PR DESCRIPTION
With this pull request, all admin functionality related to adding, editing, and reordering should be usable and the PHP portion of it covered by tests. I'm working on setting up a test suite for `coauthors.js`, and also separating it into classes, refactoring, and improving the look and feel of the UI. I will put that into a different pull request, because I think it probably needs to be evaluated separately.


